### PR TITLE
request upgraded to 2.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main" : "./lib/block_io.js",
   "dependencies" : {
-    "request"   : "2.36.0"
+    "request"   : "2.44.0"
   },
   "devDependencies": {
   	"vows": "0.7.x"


### PR DESCRIPTION
Retire.js says that there is a known vulnerability in qs (dependency of request).

$ npm install -g retire
$ retire

qs 0.6.6 has known vulnerabilities: https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
block_io 0.2.0
↳ request 2.36.0
 ↳ qs 0.6.6
