### PR TITLE
Security fix: explicitly use only TLSv1

### DIFF
--- a/lib/block_io.js
+++ b/lib/block_io.js
@@ -129,6 +129,7 @@ BlockIo.prototype._request = function (method, path, args, cb) {
 
   var opts = {
     method: method,
+    secureProtocol: 'TLSv1_method',
     headers: {
       'User-Agent': BlockIo.USER_AGENT
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name" : "block_io",
   "description" : "Block.io API wrapper for node.js",
   "keywords" : [ "block.io", "block_io", "bitcoin", "litecoin", "dogecoin", "wallet" ],
-  "version" : "1.0.0",
+  "version" : "1.0.1",
   "preferGlobal" : false,
   "homepage" : "https://github.com/BlockIo/block_io-nodejs",
   "author" : "Patrick Lodder <patrick.lodder@gmail.com> (https://github.com/patricklodder)",


### PR DESCRIPTION
Re: poodle, see http://googleonlinesecurity.blogspot.ie/2014/10/this-poodle-bites-exploiting-ssl-30.html
