### PR TITLE
Adds data even for failed requests

### DIFF
--- a/lib/block_io.js
+++ b/lib/block_io.js
@@ -242,7 +242,12 @@ BlockIo.prototype._request = function (path, args, cb) {
 
   const promise = new Promise((f,r) => {
     const next = BlockIo.parseResponse(function (e, d) {
-      if (e) return r(e);
+      if (e) {
+        if (d) {
+          e.data = d;
+        }
+        return r(e);
+      }
       f(d);
     });
 


### PR DESCRIPTION
In some cases BlockIo API returns error status code and throws with `Error`, but response contains JSON data that is needed to adjust further execution logic. Example of that is when requesting fee estimate, API responds with 404 (not sure that's a perfect error code) and data that's needed to adjust payout options.

This PR is to include aforementioned data to error if that happened, so it's possible to use that data.